### PR TITLE
Add flag '-w' to disable c warning for code generated from vala

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ add_definitions(${DEPS_CFLAGS})
 link_libraries(${DEPS_LIBRARIES})
 link_directories(${DEPS_LIBRARY_DIRS})
 
+# disable c compiler warnings
+add_definitions(-w)
+
 # make sure we have vala
 find_package(Vala REQUIRED)
 # make sure we use vala


### PR DESCRIPTION
the C compiler gives useless warnings since the c code is generated by valac, disable it to see the clear output of the build process.
