### PR TITLE
Hide Done Button on startup and during breaks

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -71,6 +71,7 @@ public class Main : Gtk.Application {
         task_timer.active_task_done.connect (task_manager.mark_task_done);
         win = new MainWindow (this, task_manager, task_timer, settings);
         win.show_all ();
+        win.timer_view.done_btn.visible = false;
     }
     
     public void show_about () {

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -31,7 +31,7 @@ class MainWindow : Gtk.ApplicationWindow {
     private Gtk.HeaderBar header_bar;
     private TaskList todo_list;
     private TaskList done_list;
-    private TimerView timer_view;
+    public TimerView timer_view;
     private Gtk.ToggleToolButton menu_btn;
     // Application Menu
     private Gtk.Menu app_menu;

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -182,6 +182,7 @@ class MainWindow : Gtk.ApplicationWindow {
         path = todo_selection.get_selected_rows (out model).nth_data (0);
         var reference = new Gtk.TreeRowReference (model, path);
         task_timer.active_task = reference;
+        timer_view.done_btn.visible = false;
     }
     
     private void menu_btn_toggled (Gtk.ToggleToolButton source) {

--- a/src/view/TimerView.vala
+++ b/src/view/TimerView.vala
@@ -102,6 +102,8 @@ public class TimerView : Gtk.Grid {
             run_btn.get_style_context ().add_class ("suggested-action");
             run_btn.clicked.connect ((e) => {
                 timer.start ();
+                if (!done_btn.visible)
+                    done_btn.visible = true;
             });
         }
     }

--- a/src/view/TimerView.vala
+++ b/src/view/TimerView.vala
@@ -206,7 +206,6 @@ public class TimerView : Gtk.Grid {
         action_task_grid = new Gtk.Grid ();
         run_btn = new Gtk.Button ();
         skip_btn = new Gtk.Button.with_label ("_Skip");
-        done_btn = new Gtk.Button.with_label ("_Done");
         
         /* Configuration */
         action_grid.orientation = Gtk.Orientation.HORIZONTAL;
@@ -215,11 +214,9 @@ public class TimerView : Gtk.Grid {
         action_task_grid.hexpand = true;
         action_timer_grid.halign = Gtk.Align.END;
         action_task_grid.halign = Gtk.Align.START;
-        done_btn.margin = 7;
         run_btn.margin = 7;
         skip_btn.margin = 7;
         // Use Mnemonics
-        done_btn.use_underline = true;
         skip_btn.use_underline = true;
         run_btn.use_underline = true;
         
@@ -227,14 +224,10 @@ public class TimerView : Gtk.Grid {
         skip_btn.clicked.connect ((e) => {
             timer.end_iteration ();
         });
-        done_btn.clicked.connect ((e) => {
-            timer.set_active_task_done();
-        });
         
         /* Add Widgets */
         action_timer_grid.add (skip_btn);
         action_timer_grid.add (run_btn);
-        action_task_grid.add (done_btn);
         action_grid.add (action_task_grid);
         action_grid.add (action_timer_grid);
         this.add (action_grid);

--- a/src/view/TimerView.vala
+++ b/src/view/TimerView.vala
@@ -76,6 +76,7 @@ public class TimerView : Gtk.Grid {
                 task_status_lbl.label = "Take a Break!";
                 style.remove_class ("task_active");
                 style.add_class ("task_break");
+                done_btn.visible = false;
             } else {
                 task_status_lbl.label = "Active Task:";
                 style.remove_class ("task_break");

--- a/src/view/TimerView.vala
+++ b/src/view/TimerView.vala
@@ -35,7 +35,7 @@ public class TimerView : Gtk.Grid {
     private Gtk.Grid action_task_grid;
     private Gtk.Button run_btn;
     private Gtk.Button skip_btn;
-    private Gtk.Button done_btn;
+    public Gtk.Button done_btn;
     
     public TimerView (TaskTimer timer) {
         this.timer = timer;
@@ -206,6 +206,7 @@ public class TimerView : Gtk.Grid {
         action_task_grid = new Gtk.Grid ();
         run_btn = new Gtk.Button ();
         skip_btn = new Gtk.Button.with_label ("_Skip");
+        done_btn = new Gtk.Button.with_label ("_Done");
         
         /* Configuration */
         action_grid.orientation = Gtk.Orientation.HORIZONTAL;
@@ -214,9 +215,11 @@ public class TimerView : Gtk.Grid {
         action_task_grid.hexpand = true;
         action_timer_grid.halign = Gtk.Align.END;
         action_task_grid.halign = Gtk.Align.START;
+        done_btn.margin = 7;
         run_btn.margin = 7;
         skip_btn.margin = 7;
         // Use Mnemonics
+        done_btn.use_underline = true;
         skip_btn.use_underline = true;
         run_btn.use_underline = true;
         
@@ -224,10 +227,14 @@ public class TimerView : Gtk.Grid {
         skip_btn.clicked.connect ((e) => {
             timer.end_iteration ();
         });
+        done_btn.clicked.connect ((e) => {
+            timer.set_active_task_done();
+        });
         
         /* Add Widgets */
         action_timer_grid.add (skip_btn);
         action_timer_grid.add (run_btn);
+        action_task_grid.add (done_btn);
         action_grid.add (action_task_grid);
         action_grid.add (action_timer_grid);
         this.add (action_grid);

--- a/src/view/TimerView.vala
+++ b/src/view/TimerView.vala
@@ -96,15 +96,17 @@ public class TimerView : Gtk.Grid {
             run_btn.label = "Pau_se";
             run_btn.get_style_context ().remove_class ("suggested-action");
             run_btn.clicked.connect ((e) => {
+                if (task_status_lbl.label == "Take a Break!")
+                    done_btn.visible = false;
                 timer.stop ();
             });
         } else {
             run_btn.label = "_Start";
             run_btn.get_style_context ().add_class ("suggested-action");
             run_btn.clicked.connect ((e) => {
-                timer.start ();
-                if (!done_btn.visible)
+                if (task_status_lbl.label == "Active Task:")
                     done_btn.visible = true;
+                timer.start ();
             });
         }
     }


### PR DESCRIPTION
#10 
I chose a quick way to hide the Done button on Startup: I changed timer_view and done_btn from **private** to **public**.

- Should I create helper methods/functions instead of making these public?

The Done button reappears once a Task is started and also when a break from the previous Task ends (this allows a user to mark the previous Task as complete after returning from their break--without having to switch to the To-Do View).

Hiding the _Done Button_ when a break starts prevents users from completing a task during a break (they should be relaxing instead).

![empty](https://cloud.githubusercontent.com/assets/10415947/5736838/9101e1d4-9ba8-11e4-89f5-81bba48d0ca8.gif)
![complete_notdonenext2](https://cloud.githubusercontent.com/assets/10415947/5738112/6d6bff1c-9bb6-11e4-851f-d3521e99d1c2.gif)



