### PR TITLE
Go For It! App icon in Notification Messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,10 @@ set (VERSION_INFO "initial release")
 # find pkgconfig to make sure dependencies are installed
 find_package(PkgConfig)
 # check for the required dependencies
-pkg_check_modules(DEPS REQUIRED gtk+-3.0)
+pkg_check_modules(DEPS REQUIRED 
+    gtk+-3.0
+    libnotify
+    )
 add_definitions(${DEPS_CFLAGS})
 link_libraries(${DEPS_LIBRARIES})
 link_directories(${DEPS_LIBRARY_DIRS})
@@ -47,6 +50,7 @@ vala_precompile(VALA_C ${EXEC_NAME}
 # tell what libraries to use when compiling
 PACKAGES
     gtk+-3.0
+    libnotify
 )
 
 # tell cmake what to call the executable we just made

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -60,6 +60,8 @@ class MainWindow : Gtk.ApplicationWindow {
         setup_widgets ();
         load_css ();
         setup_notifications ();
+        // Enable Notifications for the App
+        Notify.init (GOFI.APP_NAME);
     }
     
     public override bool delete_event (Gdk.EventAny event) {
@@ -269,25 +271,21 @@ class MainWindow : Gtk.ApplicationWindow {
         
         if (break_previously_active != break_active) {
             var task = GOFI.Utils.tree_row_ref_to_task (reference);
-            Notification notification;
+            Notify.Notification notification;
             if (break_active) {
-                notification = new Notification ("Take a Break");
-                notification.set_body ("Relax and stop thinking about your "
-                                       + "current task for a while :-)");
+                notification = new Notify.Notification ("Take a Break", "Relax and stop thinking about your current task for a while :-)", "go-for-it");
             } else {
-                notification = new Notification ("The Break is Over");
-                notification.set_body ("Your next task is: " + task);
+               notification = new Notify.Notification ("The Break is Over", "Your next task is: " + task, "go-for-it");
             }
-            application.send_notification (null, notification);
+            notification.show ();
         }
         break_previously_active = break_active;
     }
     
     private void display_almost_over_notification (DateTime remaining_time) {
         int64 secs = remaining_time.to_unix ();
-        var notification = new Notification ("Prepare for your break");
-        notification.set_body (@"You have $secs seconds left");
-        application.send_notification (null, notification);
+        Notify.Notification notification = new Notify.Notification ("Prepare for your break", @"You have $secs seconds left", "go-for-it");
+        notification.show ();
     }
     
     /**

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -280,7 +280,12 @@ class MainWindow : Gtk.ApplicationWindow {
             } else {
                notification = new Notify.Notification ("The Break is Over", "Your next task is: " + task, "go-for-it");
             }
-            notification.show ();
+            
+            try {
+                notification.show ();
+            } catch (GLib.Error err){
+                GLib.stderr.printf("Error in notify! (break_active notification)\n");
+            }
         }
         break_previously_active = break_active;
     }
@@ -288,7 +293,11 @@ class MainWindow : Gtk.ApplicationWindow {
     private void display_almost_over_notification (DateTime remaining_time) {
         int64 secs = remaining_time.to_unix ();
         Notify.Notification notification = new Notify.Notification ("Prepare for your break", @"You have $secs seconds left", "go-for-it");
-        notification.show ();
+        try {
+            notification.show ();
+        } catch (GLib.Error err){
+            GLib.stderr.printf("Error in notify! (remaining_time notification)\n");
+        }
     }
     
     /**

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -75,6 +75,9 @@ class MainWindow : Gtk.ApplicationWindow {
             hide ();
             dont_exit = true;
         }
+        
+        if (dont_exit == false) Notify.uninit ();
+            
         return dont_exit;
     }
     


### PR DESCRIPTION
Currently shows a generic blue icon (help-info.svg) and I wanted to instead see the Go-For-It App Icon (go-for-it.svg). I chose [libnotify/Notify API](https://developer.gnome.org/libnotify/0.7/NotifyNotification.html) for ease of use, it is already installed on eOS by default, and because other Elementary apps use it. 

You can test Notify in the terminal using notify-send (/usr/bin/notify-send). 

**Examples**:

    notify-send 'Hello world!' 'This is an example notification.' --icon=dialog-information

    notify-send 'Time to Work' 'Get started by picking a task.' --icon=go-for-it --expire-time=8000

I particularly like being able to set the timeout because notifications by default, in my opinion, disappear too quickly, and I sometimes miss breaks.

[Desktop Notifications Specification](https://developer.gnome.org/notification-spec/)

![booohoo](https://cloud.githubusercontent.com/assets/10415947/5900673/cf8dd0da-a539-11e4-96a7-7afbebc3a8b3.gif)![awfsome](https://cloud.githubusercontent.com/assets/10415947/5900616/33e19158-a539-11e4-8525-0f95d767ecb3.gif)

*GIFs above are low quality, hence the stuttering and incorrect colors.*
