### PR TITLE
Added a refresh option and fixed some warnings

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -29,6 +29,7 @@ public class Main : Gtk.Application {
 
     private static bool print_version = false;
     private static bool show_about_dialog = false;
+    private static bool refresh_tasks = false;
     /**
      * Constructor of the Application class.
      */
@@ -80,6 +81,14 @@ public class Main : Gtk.Application {
         win.show_all ();
     }
     
+    public void refresh () {
+        if (win == null) {
+            stdout.printf ("An instance of Go For It! needs to be running in order for this to work!\n");
+            return;
+        }
+        task_manager.refresh ();
+    }
+    
     public void show_about (Gtk.Window? parent = null) {
         var dialog = new AboutDialog (parent);
         dialog.run ();
@@ -111,6 +120,8 @@ public class Main : Gtk.Application {
             stdout.printf ("%s %s\n", GOFI.APP_NAME, GOFI.APP_VERSION);
             stdout.printf ("Copyright 2011-2014 'Go For it!' Developers.\n");
 
+        } else if (refresh_tasks) {
+            refresh ();
         } else if (show_about_dialog) {
             show_about ();
         } else {
@@ -122,6 +133,7 @@ public class Main : Gtk.Application {
 
     static const OptionEntry[] entries = {
         { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
+        { "refresh", 'r', 0, OptionArg.NONE, out refresh_tasks, N_("Refresh the current window"), null },
         { "about", 'a', 0, OptionArg.NONE, out show_about_dialog, N_("Show about dialog"), null },
         { null }
     };

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -80,8 +80,8 @@ public class Main : Gtk.Application {
         win.show_all ();
     }
     
-    public void show_about () {
-        var dialog = new AboutDialog ();
+    public void show_about (Gtk.Window? parent = null) {
+        var dialog = new AboutDialog (parent);
         dialog.run ();
     }
 

--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -109,6 +109,15 @@ class TaskManager {
         done_store.clear ();
     }
     
+    /**
+     * Reloads all tasks.
+     */
+    public void refresh () {
+        load_tasks ();
+        // Some tasks may have been marked as done by other applications.
+        auto_transfer_tasks ();
+    }
+    
     private void load_task_stores () {
         stdout.printf("load_task_stores");
         todo_txt_dir = File.new_for_path(settings.todo_txt_location);

--- a/src/view/AboutDialog.vala
+++ b/src/view/AboutDialog.vala
@@ -19,7 +19,8 @@
  * The widget for selecting, displaying and controlling the active task.
  */
 public class AboutDialog : Gtk.AboutDialog {
-    public AboutDialog () {
+    public AboutDialog (Gtk.Window? parent = null) {
+        this.set_transient_for (parent);
         /* Initalization */
         this.set_default_size (450, 500);
         this.get_content_area ().margin = 10;

--- a/src/view/ContributeDialog.vala
+++ b/src/view/ContributeDialog.vala
@@ -20,8 +20,7 @@
  */
 public class ContributeDialog : Gtk.MessageDialog {
     /* GTK Widgets */
-    public ContributeDialog ()
-    {
+    public ContributeDialog (Gtk.Window? parent) {
         Object (buttons: Gtk.ButtonsType.OK);
         this.message_type = Gtk.MessageType.INFO;
         this.set_modal (true);
@@ -45,5 +44,6 @@ public class ContributeDialog : Gtk.MessageDialog {
         
         this.get_action_area ().hexpand = false;
         this.get_action_area ().halign = Gtk.Align.END;
+        this.set_transient_for (parent);
     }
 }

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -241,7 +241,7 @@ class MainWindow : Gtk.ApplicationWindow {
         });
         
         config_item.activate.connect ((e) => {
-            var dialog = new SettingsDialog (settings);
+            var dialog = new SettingsDialog (this, settings);
             dialog.show ();
         });
         clear_done_item.activate.connect ((e) => {
@@ -253,7 +253,7 @@ class MainWindow : Gtk.ApplicationWindow {
         });
         about_item.activate.connect ((e) => {
             var app = get_application () as Main;
-            app.show_about ();
+            app.show_about (this);
         });
         
         /* Add Items to Menu */

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -248,7 +248,7 @@ class MainWindow : Gtk.ApplicationWindow {
             task_manager.clear_done_store ();
         });
         contribute_item.activate.connect ((e) => {
-            var dialog = new ContributeDialog ();
+            var dialog = new ContributeDialog (this);
             dialog.show ();
         });
         about_item.activate.connect ((e) => {

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -37,6 +37,7 @@ class MainWindow : Gtk.ApplicationWindow {
     private Gtk.Menu app_menu;
     private Gtk.MenuItem config_item;
     private Gtk.MenuItem clear_done_item;
+    private Gtk.MenuItem refresh_item;
     private Gtk.MenuItem contribute_item;
     private Gtk.MenuItem about_item;
     /**
@@ -231,6 +232,7 @@ class MainWindow : Gtk.ApplicationWindow {
         app_menu = new Gtk.Menu ();
         config_item = new Gtk.MenuItem.with_label (_("Settings"));
         clear_done_item = new Gtk.MenuItem.with_label (_("Clear Done List"));
+        refresh_item = new Gtk.MenuItem.with_label (_("Refresh"));
         contribute_item = new Gtk.MenuItem.with_label (_("Contribute / Donate"));
         about_item = new Gtk.MenuItem.with_label (_("About"));
         
@@ -247,6 +249,9 @@ class MainWindow : Gtk.ApplicationWindow {
         clear_done_item.activate.connect ((e) => {
             task_manager.clear_done_store ();
         });
+        refresh_item.activate.connect ((e) => {
+            task_manager.refresh ();
+        });
         contribute_item.activate.connect ((e) => {
             var dialog = new ContributeDialog (this);
             dialog.show ();
@@ -259,6 +264,7 @@ class MainWindow : Gtk.ApplicationWindow {
         /* Add Items to Menu */
         app_menu.add (config_item);
         app_menu.add (clear_done_item);
+        app_menu.add (refresh_item);
         app_menu.add (contribute_item);
         app_menu.add (about_item);
         

--- a/src/view/SettingsDialog.vala
+++ b/src/view/SettingsDialog.vala
@@ -32,7 +32,8 @@ public class SettingsDialog : Gtk.Dialog {
     private Gtk.Label reminder_lbl;
     private Gtk.SpinButton reminder_spin;
     
-    public SettingsDialog (SettingsManager settings) {
+    public SettingsDialog (Gtk.Window? parent, SettingsManager settings) {
+        this.set_transient_for (parent);
         this.settings = settings;
         /* Initalization */
         main_layout = new Gtk.Grid ();


### PR DESCRIPTION
Fixed warning: Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
Aside from having less warnings, dialogs now get centered over the main window.