### PR TITLE
Re-enable css support for Gtk+ < 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,11 @@ install (TARGETS ${EXEC_NAME} RUNTIME DESTINATION bin)
 # install .desktop file so the Applications menu will display it
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/go-for-it.desktop DESTINATION ${DATADIR}/applications/)
 # install the application's stylesheet
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/style/go-for-it.css DESTINATION ${PKGDATADIR}/style/)
+if (${GTK3_VERSION} VERSION_GREATER 3.4)
+    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/style/go-for-it.css DESTINATION ${PKGDATADIR}/style/)
+else ()
+    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/style/legacy-compat/go-for-it.css DESTINATION ${PKGDATADIR}/style/)
+endif ()
 # install the application's icons
 set(SYSTEM_DEFAULT_THEME ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/icons/hicolor/16x16/apps/go-for-it.svg DESTINATION ${SYSTEM_DEFAULT_THEME}/16x16/apps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ install (TARGETS ${EXEC_NAME} RUNTIME DESTINATION bin)
 # install .desktop file so the Applications menu will display it
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/go-for-it.desktop DESTINATION ${DATADIR}/applications/)
 # install the application's stylesheet
-if (${GTK3_VERSION} VERSION_GREATER 3.4)
+if (${GTK3_VERSION} VERSION_GREATER 3.7)
     install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/style/go-for-it.css DESTINATION ${PKGDATADIR}/style/)
 else ()
     install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/style/legacy-compat/go-for-it.css DESTINATION ${PKGDATADIR}/style/)

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -427,7 +427,6 @@ class MainWindow : Gtk.ApplicationWindow {
      * applied to the application.
      */
     private void load_css () {
-#if HAS_GTK310
         var screen = this.get_screen();
         var css_provider = new Gtk.CssProvider();
         // Scan all potential data dirs for the corresponding css file
@@ -446,7 +445,6 @@ class MainWindow : Gtk.ApplicationWindow {
                 }
             }
         }
-#endif
     }
     
     /**

--- a/style/legacy-compat/go-for-it.css
+++ b/style/legacy-compat/go-for-it.css
@@ -1,0 +1,21 @@
+GtkLabel.task_status {
+    font-size: 20;
+    font-weight: bold;
+}
+
+GtkLabel.task_break {
+    font-size: 12;
+    color: #ababab;
+}
+
+GtkLabel.task_active {
+    font-size: 12;
+}
+
+.timerview GtkSpinButton {
+    font-size: 40;
+}
+
+.timerview GtkLabel {
+    font-size: 25;
+}


### PR DESCRIPTION
Quick css fix for precise.
I assumed 10pt and converted the percentages to new font sizes.