### PR TITLE
Fixes #67

### DIFF
--- a/data/go-for-it.desktop
+++ b/data/go-for-it.desktop
@@ -7,6 +7,7 @@ Exec=go-for-it
 Icon=go-for-it
 Terminal=false
 Type=Application
+StartupWMClass=go-for-it
 X-GNOME-Gettext-Domain=go-for-it
 Keywords=Productivity;Todo.txt;Todo;Timer;Task;PIM;Time Management;
 X-GNOME-Keywords=Productivity;Todo.txt;Todo;Timer;Task;PIM;Time Management;


### PR DESCRIPTION
This will fix the icon issue on XFCE and other desktop environments.
Why adding a StartupWMClass? It's needed for some desktop envs to detect the executable application and link it with the correct desktop file.
You can get the correct StartupWMClass using `xprop WM_CLASS` and click on the running application/window. 