### PR TITLE
Add appdata file

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,6 +1,9 @@
 # install .desktop file so the Applications menu will display it
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/go-for-it.desktop DESTINATION ${DATADIR}/applications/)
 
+# install appdata file which provides metadata for software centers
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/go-for-it.appdata.xml DESTINATION ${DATADIR}/metainfo/)
+
 # install the application's icons
 set(SYSTEM_DEFAULT_THEME ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/hicolor/16x16/apps/go-for-it.svg DESTINATION ${SYSTEM_DEFAULT_THEME}/16x16/apps)

--- a/data/go-for-it.appdata.xml
+++ b/data/go-for-it.appdata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Patrik Nilsson -->
+<component type="desktop-application">
+  <id>de.manuel_kehl.go-for-it.desktop</id>
+  <name>Go For It!</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <summary>A stylish to-do list with built-in productivity timer</summary>
+  <developer_name>Jonathan Moerman</developer_name>
+  <description>
+    <p>
+      Go For It! is a simple and stylish productivity app, featuring a to-do
+      list, merged with a timer that keeps your focus on the current task.
+    </p>
+    <p>
+      To-do lists are stored in the Todo.txt format. This simplifies
+      synchronization with mobile devices and makes it possible to edit tasks
+      using other front-ends, like my Todo.txt Kupfer Plugin.
+    </p>
+    <p>
+      If you already use Todo.txt, beware of the fact, that Go For It!
+      automatically archives completed tasks to the done list!
+    </p>
+  </description>
+  <url type="homepage">http://manuel-kehl.de/projects/go-for-it/</url>
+  <url type="bugtracker">https://github.com/mank319/Go-For-It/issues</url>
+  <url type="help">https://github.com/mank319/Go-For-It/blob/master/README.md</url>
+  <url type="translate">https://translations.launchpad.net/go-for-it</url>
+  <update_contact>contact_AT_hembas.se</update_contact>
+  <translation type="gettext">go-for-it</translation>
+</component>


### PR DESCRIPTION
This is used by Software Centers and packaging systems that make use of
the AppStream specification. It adds distribution independent metadata
for the project.

Screenshots are not supplied due to the extra work needed to make new
ones that comply with the AppStream recommendations. Specifically the
difficulty lies in only showing the window, yet maintaining an aspect
ratio of 16:9.

Not sure how this is best solved. Likely the only solution is to
something similar to the current screenshot.jpg, minus the background
and no padding.

This appdata file validates using `appstream-util validate-relax`.

Should fix #121