### PR TITLE
Todo.txt dir command line option

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -25,6 +25,7 @@ class Main : Gtk.Application {
     private TaskTimer task_timer;
     private MainWindow win;
 
+    private static string? todo_txt_location = null;
     private static bool print_version = false;
     private static bool show_about_dialog = false;
     /**
@@ -43,7 +44,7 @@ class Main : Gtk.Application {
         }
 
         settings = new SettingsManager.load_from_key_file ();
-        task_manager = new TaskManager(settings);
+        task_manager = new TaskManager(settings, todo_txt_location);
         task_timer = new TaskTimer (settings);
         task_timer.active_task_done.connect ( (task) => {
              task_manager.mark_task_done (task);
@@ -92,6 +93,7 @@ class Main : Gtk.Application {
     }
 
     const OptionEntry[] entries = {
+        { "todotxt-dir", 'd', 0, OptionArg.FILENAME, out todo_txt_location, N_("Use different Todo.txt directory"), N_("path") },
         { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
         { "about", 'a', 0, OptionArg.NONE, out show_about_dialog, N_("Show about dialog"), null },
         { null }

--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -25,6 +25,7 @@ class TaskManager {
     private SettingsManager settings;
     // The user's todo.txt related files
     public string? todo_txt_location = null;
+    public string? instance_str = null;
     private File todo_txt_dir;
     private File todo_txt;
     private File done_txt;
@@ -171,6 +172,10 @@ class TaskManager {
     private void load_task_stores (string location) {
         stdout.printf("load_task_stores\n");
         todo_txt_dir = File.new_for_commandline_arg(location);
+        if (this.todo_txt_location != null) {
+            FileInfo finfo = todo_txt_dir.query_info(FileAttribute.STANDARD_NAME, 0);
+            this.instance_str = finfo.get_name();
+        }
         todo_txt = todo_txt_dir.get_child ("todo.txt");
         done_txt = todo_txt_dir.get_child ("done.txt");
 

--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -173,7 +173,7 @@ class TaskManager {
         stdout.printf("load_task_stores\n");
         todo_txt_dir = File.new_for_commandline_arg(location);
         if (this.todo_txt_location != null) {
-            FileInfo finfo = todo_txt_dir.query_info(FileAttribute.STANDARD_NAME, 0);
+            FileInfo finfo = todo_txt_dir.get_parent().query_info(FileAttribute.STANDARD_NAME, 0);
             this.instance_str = finfo.get_name();
         }
         todo_txt = todo_txt_dir.get_child ("todo.txt");

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -25,6 +25,7 @@ class MainWindow : Gtk.ApplicationWindow {
     private SettingsManager settings;
     private bool use_header_bar;
     private bool refreshing = false;
+    private string? instance_str = null;
 
     /* Various GTK Widgets */
     private Gtk.Grid main_layout;
@@ -57,6 +58,12 @@ class MainWindow : Gtk.ApplicationWindow {
         this.task_manager = task_manager;
         this.task_timer = task_timer;
         this.settings = settings;
+
+        if (this.task_manager.instance_str != null) {
+            this.instance_str = this.task_manager.instance_str + " — " + GOFI.APP_NAME;
+        } else {
+            this.instance_str = GOFI.APP_NAME;
+        }
 
         apply_settings ();
 
@@ -107,7 +114,7 @@ class MainWindow : Gtk.ApplicationWindow {
      * Configures the window's properties.
      */
     private void setup_window () {
-        this.title = GOFI.APP_NAME;
+        this.title = this.instance_str;
         this.set_border_width (0);
         restore_win_geometry ();
     }
@@ -210,7 +217,7 @@ class MainWindow : Gtk.ApplicationWindow {
 
         // GTK Header Bar
         header_bar.set_show_close_button (true);
-        header_bar.title = GOFI.APP_NAME;
+        header_bar.title = this.instance_str;
 
         // Add headerbar Buttons here
         header_bar.pack_end (menu_btn);

--- a/src/view/MainWindow.vala
+++ b/src/view/MainWindow.vala
@@ -25,7 +25,6 @@ class MainWindow : Gtk.ApplicationWindow {
     private SettingsManager settings;
     private bool use_header_bar;
     private bool refreshing = false;
-    private string? instance_str = null;
 
     /* Various GTK Widgets */
     private Gtk.Grid main_layout;
@@ -58,12 +57,6 @@ class MainWindow : Gtk.ApplicationWindow {
         this.task_manager = task_manager;
         this.task_timer = task_timer;
         this.settings = settings;
-
-        if (this.task_manager.instance_str != null) {
-            this.instance_str = this.task_manager.instance_str + " — " + GOFI.APP_NAME;
-        } else {
-            this.instance_str = GOFI.APP_NAME;
-        }
 
         apply_settings ();
 
@@ -114,7 +107,11 @@ class MainWindow : Gtk.ApplicationWindow {
      * Configures the window's properties.
      */
     private void setup_window () {
-        this.title = this.instance_str;
+        if (this.task_manager.instance_str != null) {
+            this.title = this.task_manager.instance_str + " — " + GOFI.APP_NAME;
+        } else {
+            this.title = GOFI.APP_NAME;
+        }
         this.set_border_width (0);
         restore_win_geometry ();
     }
@@ -217,7 +214,13 @@ class MainWindow : Gtk.ApplicationWindow {
 
         // GTK Header Bar
         header_bar.set_show_close_button (true);
-        header_bar.title = this.instance_str;
+        header_bar.title = GOFI.APP_NAME;
+        if (this.task_manager.instance_str != null) {
+            header_bar.subtitle = this.task_manager.instance_str;
+            header_bar.has_subtitle = true;
+        } else {
+            header_bar.has_subtitle = false;
+        }
 
         // Add headerbar Buttons here
         header_bar.pack_end (menu_btn);


### PR DESCRIPTION
Feature to run with arbitrary Todo.txt directory would allow to add such directories in projects and edit project-related todos in very convenient way.

When runing with custom dir, name of containing dir is displayed in window caption - i.e., if you set it to ~/dev/myapp/Todo, name will be "myapp — Go For It!".

For example:
```
$ cd ~/dist
$ com.github.jmoerman.go-for-it -d ~/dist/tasks
load_task_stores
Reading file: /home/nick87720z/dist/tasks/todo.txt
Reading file: /home/nick87720z/dist/tasks/done.txt
```
![go-for-it-dist-todo](https://user-images.githubusercontent.com/3896190/43552325-84deed94-9603-11e8-8db0-3f64d9e1fef8.png)