### PR TITLE
Add support for creation and completion dates

### DIFF
--- a/src/TaskManager.vala
+++ b/src/TaskManager.vala
@@ -90,6 +90,7 @@ class TaskManager {
     public void add_new_task (string task) {
         string _task = task.strip ();
         if (_task != "") {
+            _task = GOFI.Utils.prepend_today(_task);
             todo_store.add_task (new TodoTask (_task, false));
             save_todo_tasks ();
         }

--- a/src/TodoTask.vala
+++ b/src/TodoTask.vala
@@ -36,6 +36,14 @@ public class TodoTask : GLib.Object {
         }
         public set {
             if (_done != value) {
+                if (value) {
+                    _title = GOFI.Utils.prepend_today(GOFI.Utils.remove_priority(_title));
+                } else {
+                    string[] parts = _title.split(" ");
+                    if (GOFI.Utils.is_date(parts[0])) {
+                        _title = string.joinv(" ", parts[1:parts.length]);
+                    }
+                }
                 _done = value;
                 done_changed ();
             }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -158,5 +158,41 @@ namespace GOFI {
                 }
             }
         }
+
+        /**
+         * Checks whether token is a date in the todo.txt format.
+         */
+        public static bool is_date (string token) {
+            MatchInfo info;
+            return /\d\d\d\d-\d\d-\d\d/.match(token, 0, out info);
+        }
+
+        /**
+         * Checks whether token is a priority in the todo.txt format.
+         */
+        public static bool is_priority (string token) {
+            MatchInfo info;
+            return /\([A-Z]\)/.match(token, 0, out info);
+        }
+
+        /**
+         * Adds the current date in the todo.txt format to the front of the title.
+         * Used for adding creation/completion date.
+         */
+        public static string prepend_today (string txt) {
+            return new GLib.DateTime.now_local ().format ("%Y-%m-%d") + " " + txt;
+        }
+
+
+        /**
+         * Removes todo item priority.
+         */
+        public static string remove_priority (string txt) {
+            string[] parts = txt.split(" ");
+            if (is_priority(parts[0])) {
+                return string.joinv(" ", parts[1:parts.length]);
+            }
+            return txt;
+        }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/mank319/Go-For-It/issues/55.

The format specification states that a completion date is [mandatory](https://github.com/todotxt/todo.txt/blob/master/README.md#rule-2-a-tasks-creation-date-may-optionally-appear-directly-after-priority-and-a-space) and a
creation date can be [optionally added](https://github.com/todotxt/todo.txt/blob/master/README.md#rule-2-a-tasks-creation-date-may-optionally-appear-directly-after-priority-and-a-space). The format states that "Many Todo.txt
clients discard priority on task completion." This is one of them partly in
order to simplify the date parsing logic but also it's the logical thing to do.